### PR TITLE
Add 'sprout list' command to list all worktrees

### DIFF
--- a/bin/sprout
+++ b/bin/sprout
@@ -35,6 +35,8 @@ Commands:
   dir <name>          Print the directory path of a worktree
 
   list                List all worktrees in the current repository
+                      Options:
+                        --verbose, --full, -v   Show full paths instead of names
 
   rm <name>           Remove a worktree
                       Options:

--- a/bin/sprout
+++ b/bin/sprout
@@ -16,6 +16,7 @@ source "$LIB_DIR/utils.sh"
 # Source command implementations
 source "$LIB_DIR/commands/add.sh"
 source "$LIB_DIR/commands/dir.sh"
+source "$LIB_DIR/commands/list.sh"
 source "$LIB_DIR/commands/rm.sh"
 source "$LIB_DIR/commands/open.sh"
 
@@ -32,6 +33,8 @@ Commands:
                         -b <branch>   Checkout a specific branch (default: main)
 
   dir <name>          Print the directory path of a worktree
+
+  list                List all worktrees in the current repository
 
   rm <name>           Remove a worktree
                       Options:
@@ -66,7 +69,7 @@ parse_args() {
     local cmd="${1:-}"
 
     case "$cmd" in
-        add|dir|rm|open|config|help|-h|--help|"")
+        add|dir|list|rm|open|config|help|-h|--help|"")
             return 0
             ;;
         *)
@@ -90,6 +93,9 @@ main() {
             ;;
         dir)
             cmd_dir "$@"
+            ;;
+        list)
+            cmd_list "$@"
             ;;
         rm)
             cmd_rm "$@"

--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# sprout list command - List all worktrees
+
+cmd_list() {
+    local worktrees_dir
+    worktrees_dir=$(get_repo_worktrees_dir) || return 1
+
+    # Check if worktrees directory exists
+    if [[ ! -d "$worktrees_dir" ]]; then
+        # No worktrees exist yet, exit silently
+        return 0
+    fi
+
+    # List all directories in the worktrees directory
+    # Each directory represents a worktree
+    for dir in "$worktrees_dir"/*; do
+        if [[ -d "$dir" ]]; then
+            basename "$dir"
+        fi
+    done
+}

--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -3,6 +3,23 @@
 
 cmd_list() {
     local worktrees_dir
+    local verbose=false
+
+    # Parse options
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --verbose|--full|-v)
+                verbose=true
+                shift
+                ;;
+            *)
+                echo "Error: Unknown option '$1'" >&2
+                echo "Usage: sprout list [--verbose|--full|-v]" >&2
+                return 1
+                ;;
+        esac
+    done
+
     worktrees_dir=$(get_repo_worktrees_dir) || return 1
 
     # Check if worktrees directory exists
@@ -11,11 +28,21 @@ cmd_list() {
         return 0
     fi
 
-    # List all directories in the worktrees directory
-    # Each directory represents a worktree
+    # Collect valid worktrees into an array
+    local -a worktrees=()
+
     for dir in "$worktrees_dir"/*; do
-        if [[ -d "$dir" ]]; then
-            basename "$dir"
+        if [[ -d "$dir" ]] && is_git_worktree "$dir"; then
+            if [[ "$verbose" == true ]]; then
+                worktrees+=("$dir")
+            else
+                worktrees+=("$(basename "$dir")")
+            fi
         fi
     done
+
+    # Sort and print worktrees
+    if [[ ${#worktrees[@]} -gt 0 ]]; then
+        printf '%s\n' "${worktrees[@]}" | sort
+    fi
 }

--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -28,18 +28,25 @@ cmd_list() {
         return 0
     fi
 
-    # Collect valid worktrees into an array
+    # Collect valid worktrees into an array using git worktree list
     local -a worktrees=()
 
-    for dir in "$worktrees_dir"/*; do
-        if [[ -d "$dir" ]] && is_git_worktree "$dir"; then
-            if [[ "$verbose" == true ]]; then
-                worktrees+=("$dir")
-            else
-                worktrees+=("$(basename "$dir")")
+    # Use git worktree list to get all worktrees, then filter for our managed directory
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+            local worktree_path="${BASH_REMATCH[1]}"
+            # Only include worktrees in our managed directory
+            if [[ "$worktree_path" == "$worktrees_dir"/* ]]; then
+                if [[ "$verbose" == true ]]; then
+                    worktrees+=("$worktree_path")
+                else
+                    # Extract relative path from worktrees_dir
+                    local relative_path="${worktree_path#"$worktrees_dir/"}"
+                    worktrees+=("$relative_path")
+                fi
             fi
         fi
-    done
+    done < <(git worktree list --porcelain)
 
     # Sort and print worktrees
     if [[ ${#worktrees[@]} -gt 0 ]]; then

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -45,6 +45,7 @@ test_libraries_exist() {
     [ -f "$PROJECT_ROOT/lib/hooks.sh" ] && \
     [ -f "$PROJECT_ROOT/lib/commands/add.sh" ] && \
     [ -f "$PROJECT_ROOT/lib/commands/dir.sh" ] && \
+    [ -f "$PROJECT_ROOT/lib/commands/list.sh" ] && \
     [ -f "$PROJECT_ROOT/lib/commands/rm.sh" ] && \
     [ -f "$PROJECT_ROOT/lib/commands/open.sh" ]
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -217,6 +217,68 @@ test_list_verbose() {
     [ "$has_full_path" = true ]
 }
 
+# Test: List command with slash in worktree name
+test_list_with_slash() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    # Create a test repo
+    local test_repo="$temp_dir/test-repo"
+    git init "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    # Create initial commit
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    # Initialize sprout config
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create worktrees with slashes in names
+    "$PROJECT_ROOT/bin/sprout" add "feat/add-new-feature" > /dev/null 2>&1 || true
+    "$PROJECT_ROOT/bin/sprout" add "fix/bug-123" > /dev/null 2>&1 || true
+    "$PROJECT_ROOT/bin/sprout" add "simple" > /dev/null 2>&1 || true
+
+    # Get list output
+    local output
+    output=$("$PROJECT_ROOT/bin/sprout" list 2>&1)
+
+    # Convert to array for checking
+    local -a lines
+    mapfile -t lines <<< "$output"
+
+    # Should have 3 worktrees
+    local count=${#lines[@]}
+
+    # Check that full names with slashes are preserved
+    local has_feat=false
+    local has_fix=false
+    local has_simple=false
+
+    for line in "${lines[@]}"; do
+        if [[ "$line" == "feat/add-new-feature" ]]; then
+            has_feat=true
+        elif [[ "$line" == "fix/bug-123" ]]; then
+            has_fix=true
+        elif [[ "$line" == "simple" ]]; then
+            has_simple=true
+        fi
+    done
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    # Verify all worktrees were found with correct names
+    [ "$count" -eq 3 ] && [ "$has_feat" = true ] && [ "$has_fix" = true ] && [ "$has_simple" = true ]
+}
+
 # Run all tests
 echo "Core Tests:"
 echo "-----------"
@@ -237,6 +299,7 @@ echo "-------------------"
 run_test "List command with no worktrees" "test_list_empty"
 run_test "List command output is sorted" "test_list_sorted"
 run_test "List command with --verbose flag" "test_list_verbose"
+run_test "List command with slash in worktree name" "test_list_with_slash"
 
 echo ""
 echo "======================="

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -100,6 +100,123 @@ test_syntax_check() {
     done
 }
 
+# Test: List command with no worktrees
+test_list_empty() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    # Create a test repo
+    local test_repo="$temp_dir/test-repo"
+    git init "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+
+    # Initialize sprout config
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+
+    # List should succeed with no output
+    local output
+    output=$("$PROJECT_ROOT/bin/sprout" list 2>&1)
+    local exit_code=$?
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo"
+    rm -rf "$temp_dir"
+
+    # Check exit code is 0 and output is empty
+    [ $exit_code -eq 0 ] && [ -z "$output" ]
+}
+
+# Test: List command output is sorted
+test_list_sorted() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    # Create a test repo
+    local test_repo="$temp_dir/test-repo"
+    git init "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    # Create initial commit
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    # Initialize sprout config
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create worktrees in non-alphabetical order
+    "$PROJECT_ROOT/bin/sprout" add "zebra" > /dev/null 2>&1 || true
+    "$PROJECT_ROOT/bin/sprout" add "alpha" > /dev/null 2>&1 || true
+    "$PROJECT_ROOT/bin/sprout" add "middle" > /dev/null 2>&1 || true
+
+    # Get list output
+    local output
+    output=$("$PROJECT_ROOT/bin/sprout" list 2>&1)
+
+    # Check if output is sorted (alpha, middle, zebra)
+    local expected="alpha
+middle
+zebra"
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    # Compare output
+    [ "$output" = "$expected" ]
+}
+
+# Test: List command with --verbose flag
+test_list_verbose() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    # Create a test repo
+    local test_repo="$temp_dir/test-repo"
+    git init "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    # Create initial commit
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    # Initialize sprout config
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create a worktree
+    "$PROJECT_ROOT/bin/sprout" add "test-wt" > /dev/null 2>&1 || true
+
+    # Get verbose output
+    local output
+    output=$("$PROJECT_ROOT/bin/sprout" list --verbose 2>&1)
+
+    # Verbose output should contain full path
+    local has_full_path=false
+    if [[ "$output" == *"/worktrees/"* ]]; then
+        has_full_path=true
+    fi
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    # Check if full path was shown
+    [ "$has_full_path" = true ]
+}
+
 # Run all tests
 echo "Core Tests:"
 echo "-----------"
@@ -113,6 +230,13 @@ echo "Configuration Tests:"
 echo "-------------------"
 run_test "Config initialization" "test_config_init"
 run_test "Config get/set operations" "test_config_operations"
+
+echo ""
+echo "List Command Tests:"
+echo "-------------------"
+run_test "List command with no worktrees" "test_list_empty"
+run_test "List command output is sorted" "test_list_sorted"
+run_test "List command with --verbose flag" "test_list_verbose"
 
 echo ""
 echo "======================="


### PR DESCRIPTION
Implements the 'sprout list' command that lists all open worktrees in the current repository. The command reads all directories from the worktree base directory and prints their names, one per line.

## Changes
- Added lib/commands/list.sh with cmd_list implementation
- Updated bin/sprout to source and handle the list command
- Updated help text to include the list command
- Updated tests/run_tests.sh to include list.sh in library check

Resolves #1

Generated with [Claude Code](https://claude.ai/code)) | [Branch](https://github.com/johannesstricker/sprout/tree/claude/issue-1-20251118-0707) | [View job run](https://github.com/johannesstricker/sprout/actions/runs/19457300793