### PR TITLE
Add cleanup command to remove merged worktrees

### DIFF
--- a/bin/sprout
+++ b/bin/sprout
@@ -21,6 +21,7 @@ source "$LIB_DIR/commands/rm.sh"
 source "$LIB_DIR/commands/open.sh"
 source "$LIB_DIR/commands/start.sh"
 source "$LIB_DIR/commands/checkout.sh"
+source "$LIB_DIR/commands/cleanup.sh"
 
 # Display help message
 show_help() {
@@ -53,6 +54,10 @@ Commands:
 
   checkout <branch>   Checkout an existing branch into a new worktree
 
+  cleanup             Remove worktrees whose branches have been merged
+                      Options:
+                        -n, --dry-run   Show what would be removed without removing
+
   config              Manage sprout configuration
                       Subcommands:
                         set <key> <value>   Set a configuration value
@@ -80,7 +85,7 @@ parse_args() {
     local cmd="${1:-}"
 
     case "$cmd" in
-        add|dir|list|rm|open|start|checkout|config|help|-h|--help|"")
+        add|dir|list|rm|open|start|checkout|cleanup|config|help|-h|--help|"")
             return 0
             ;;
         *)
@@ -119,6 +124,9 @@ main() {
             ;;
         checkout)
             cmd_checkout "$@"
+            ;;
+        cleanup)
+            cmd_cleanup "$@"
             ;;
         config)
             cmd_config "$@"

--- a/completions/_sprout
+++ b/completions/_sprout
@@ -30,6 +30,7 @@ _sprout() {
         'open:Open a worktree with the configured editor'
         'start:Create a new worktree and open it in the editor'
         'checkout:Checkout an existing branch into a new worktree'
+        'cleanup:Remove worktrees whose branches have been merged'
         'config:Manage sprout configuration'
         'help:Show help message'
     )
@@ -74,6 +75,10 @@ _sprout() {
                     ;;
                 checkout)
                     _arguments '1:branch:_sprout_branches'
+                    ;;
+                cleanup)
+                    _arguments \
+                        '(-n --dry-run)'{-n,--dry-run}'[Show what would be removed]'
                     ;;
                 config)
                     local -a config_subcmds

--- a/completions/sprout.bash
+++ b/completions/sprout.bash
@@ -4,7 +4,7 @@ _sprout() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="add dir list rm open start checkout config help"
+    local commands="add dir list rm open start checkout cleanup config help"
     local config_subcmds="set get show"
     local config_keys="worktree_dir editor"
 
@@ -101,6 +101,11 @@ _sprout() {
             local branches
             branches=$(git branch -a --format='%(refname:short)' 2>/dev/null | sed 's|^origin/||' | sort -u)
             COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+            ;;
+        cleanup)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-n --dry-run" -- "$cur"))
+            fi
             ;;
         config)
             if [[ $cword -eq 2 ]]; then

--- a/completions/sprout.fish
+++ b/completions/sprout.fish
@@ -45,6 +45,7 @@ complete -c sprout -n __sprout_needs_command -a rm -d 'Remove a worktree'
 complete -c sprout -n __sprout_needs_command -a open -d 'Open a worktree with the configured editor'
 complete -c sprout -n __sprout_needs_command -a start -d 'Create a new worktree and open it in the editor'
 complete -c sprout -n __sprout_needs_command -a checkout -d 'Checkout an existing branch into a new worktree'
+complete -c sprout -n __sprout_needs_command -a cleanup -d 'Remove worktrees whose branches have been merged'
 complete -c sprout -n __sprout_needs_command -a config -d 'Manage sprout configuration'
 complete -c sprout -n __sprout_needs_command -a help -d 'Show help message'
 
@@ -73,6 +74,9 @@ complete -c sprout -n '__sprout_using_command checkout' -a '(__sprout_branches)'
 # start: -b <branch> + -e <editor>
 complete -c sprout -n '__sprout_using_command start' -s b -d 'Checkout a specific branch' -xa '(__sprout_branches)'
 complete -c sprout -n '__sprout_using_command start' -s e -l editor -d 'Use specific editor'
+
+# cleanup: flags
+complete -c sprout -n '__sprout_using_command cleanup' -s n -l dry-run -d 'Show what would be removed'
 
 # config: subcommands
 complete -c sprout -n __sprout_config_needs_subcmd -a set -d 'Set a configuration value'

--- a/lib/commands/cleanup.sh
+++ b/lib/commands/cleanup.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# sprout cleanup command - Remove worktrees whose branches have been merged to main
+
+cmd_cleanup() {
+    local dry_run=false
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -n|--dry-run)
+                dry_run=true
+                shift
+                ;;
+            -*)
+                echo "Error: Unknown option '$1'" >&2
+                echo "Usage: sprout cleanup [-n|--dry-run]" >&2
+                return 1
+                ;;
+            *)
+                echo "Error: Unexpected argument '$1'" >&2
+                echo "Usage: sprout cleanup [-n|--dry-run]" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    local worktrees_dir
+    worktrees_dir=$(get_repo_worktrees_dir) || return 1
+
+    # Check if worktrees directory exists
+    if [[ ! -d "$worktrees_dir" ]]; then
+        echo "No worktrees to clean up"
+        return 0
+    fi
+
+    local default_branch
+    default_branch=$(get_default_branch)
+
+    # Collect managed worktrees
+    local -a to_remove=()
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+            local worktree_path="${BASH_REMATCH[1]}"
+            if [[ "$worktree_path" == "$worktrees_dir"/* ]]; then
+                # Get the branch checked out in this worktree
+                local branch
+                branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
+
+                # Check if the branch has been merged into the default branch
+                if git merge-base --is-ancestor "$branch" "$default_branch" 2>/dev/null; then
+                    local name="${worktree_path#"$worktrees_dir/"}"
+                    to_remove+=("$name")
+                fi
+            fi
+        fi
+    done < <(git worktree list --porcelain)
+
+    if [[ ${#to_remove[@]} -eq 0 ]]; then
+        echo "No merged worktrees to clean up"
+        return 0
+    fi
+
+    if [[ "$dry_run" == true ]]; then
+        echo "Would remove the following worktrees:"
+        for name in "${to_remove[@]}"; do
+            echo "  $name"
+        done
+        return 0
+    fi
+
+    for name in "${to_remove[@]}"; do
+        local worktree_path="${worktrees_dir}/${name}"
+        local branch
+        branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || true
+
+        echo "Removing worktree '$name'..."
+        if git worktree remove --force "$worktree_path" 2>/dev/null; then
+            # Delete the branch if it still exists
+            if [[ -n "$branch" ]] && [[ "$branch" != "$default_branch" ]]; then
+                if git rev-parse --verify "$branch" > /dev/null 2>&1; then
+                    git branch -d "$branch" 2>/dev/null || true
+                fi
+            fi
+            echo "  Removed worktree and branch '$branch'"
+        else
+            echo "  Warning: Failed to remove worktree '$name'" >&2
+        fi
+    done
+
+    # Clean up empty parent directory
+    if [[ -d "$worktrees_dir" ]] && [[ -z "$(ls -A "$worktrees_dir" 2>/dev/null)" ]]; then
+        rmdir "$worktrees_dir" 2>/dev/null || true
+    fi
+
+    echo "Cleanup complete: removed ${#to_remove[@]} worktree(s)"
+}

--- a/lib/commands/cleanup.sh
+++ b/lib/commands/cleanup.sh
@@ -10,11 +10,13 @@ cmd_cleanup() {
     local -a to_remove=()
     local -a to_remove_branches=()
     local removed_count=0
+    local skipped_count=0
     local i
     local name
     local branch
     local worktree_path
     local remove_error
+    local branch_deleted
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -95,15 +97,23 @@ cmd_cleanup() {
         echo "Removing worktree '$name'..."
         if remove_error=$(git worktree remove "$worktree_path" 2>&1); then
             # Delete the branch if it still exists
+            branch_deleted=false
             if [[ -n "$branch" ]] && [[ "$branch" != "$default_branch" ]]; then
                 if git rev-parse --verify "$branch" > /dev/null 2>&1; then
-                    git branch -d "$branch" 2>/dev/null || true
+                    if git branch -d "$branch" 2>/dev/null; then
+                        branch_deleted=true
+                    fi
                 fi
             fi
-            echo "  Removed worktree and branch '$branch'"
+            if [[ "$branch_deleted" == true ]]; then
+                echo "  Removed worktree and branch '$branch'"
+            else
+                echo "  Removed worktree '$name' (branch '$branch' could not be deleted)"
+            fi
             ((removed_count++))
         else
             echo "  Skipping '$name': $remove_error (use 'sprout rm -f $name' to force)" >&2
+            ((skipped_count++))
         fi
     done
 
@@ -113,4 +123,7 @@ cmd_cleanup() {
     fi
 
     echo "Cleanup complete: removed ${removed_count} worktree(s)"
+    if [[ $skipped_count -gt 0 ]]; then
+        return 1
+    fi
 }

--- a/lib/commands/cleanup.sh
+++ b/lib/commands/cleanup.sh
@@ -75,7 +75,7 @@ cmd_cleanup() {
         branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || true
 
         echo "Removing worktree '$name'..."
-        if git worktree remove --force "$worktree_path" 2>/dev/null; then
+        if git worktree remove "$worktree_path" 2>/dev/null; then
             # Delete the branch if it still exists
             if [[ -n "$branch" ]] && [[ "$branch" != "$default_branch" ]]; then
                 if git rev-parse --verify "$branch" > /dev/null 2>&1; then
@@ -84,7 +84,7 @@ cmd_cleanup() {
             fi
             echo "  Removed worktree and branch '$branch'"
         else
-            echo "  Warning: Failed to remove worktree '$name'" >&2
+            echo "  Skipping '$name': worktree has uncommitted changes (use 'sprout rm -f $name' to force)" >&2
         fi
     done
 

--- a/lib/commands/cleanup.sh
+++ b/lib/commands/cleanup.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
-# sprout cleanup command - Remove worktrees whose branches have been merged to main
+# sprout cleanup command - Remove worktrees whose branches have been merged to the default branch
 
 cmd_cleanup() {
     local dry_run=false
+    local worktrees_dir
+    local default_branch
+    local current_path=""
+    local current_branch=""
+    local -a to_remove=()
+    local -a to_remove_branches=()
+    local removed_count=0
+    local i
+    local name
+    local branch
+    local worktree_path
+    local remove_error
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -24,7 +36,6 @@ cmd_cleanup() {
         esac
     done
 
-    local worktrees_dir
     worktrees_dir=$(get_repo_worktrees_dir) || return 1
 
     # Check if worktrees directory exists
@@ -33,26 +44,33 @@ cmd_cleanup() {
         return 0
     fi
 
-    local default_branch
-    default_branch=$(get_default_branch)
+    default_branch=$(get_default_branch) || return 1
 
-    # Collect managed worktrees
-    local -a to_remove=()
-
+    # Collect managed worktrees whose branches have been merged into the default branch.
+    # Parse git worktree list --porcelain to get both path and branch in a single pass,
+    # avoiding a separate git subprocess per worktree.
     while IFS= read -r line; do
         if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
-            local worktree_path="${BASH_REMATCH[1]}"
-            if [[ "$worktree_path" == "$worktrees_dir"/* ]]; then
-                # Get the branch checked out in this worktree
-                local branch
-                branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
-
-                # Check if the branch has been merged into the default branch
-                if git merge-base --is-ancestor "$branch" "$default_branch" 2>/dev/null; then
-                    local name="${worktree_path#"$worktrees_dir/"}"
-                    to_remove+=("$name")
+            current_path="${BASH_REMATCH[1]}"
+            current_branch=""
+        elif [[ "$line" =~ ^branch\ refs/heads/(.+)$ ]]; then
+            current_branch="${BASH_REMATCH[1]}"
+        elif [[ "$line" == "detached" ]]; then
+            current_branch="HEAD"
+        elif [[ -z "$line" ]] && [[ -n "$current_path" ]]; then
+            # End of a worktree block — check if it should be removed.
+            # Skip: worktrees outside the managed dir, detached HEAD, or on the default branch itself.
+            if [[ "$current_path" == "$worktrees_dir"/* ]] && \
+               [[ -n "$current_branch" ]] && \
+               [[ "$current_branch" != "HEAD" ]] && \
+               [[ "$current_branch" != "$default_branch" ]]; then
+                if git merge-base --is-ancestor "$current_branch" "$default_branch" 2>/dev/null; then
+                    to_remove+=("${current_path#"$worktrees_dir/"}")
+                    to_remove_branches+=("$current_branch")
                 fi
             fi
+            current_path=""
+            current_branch=""
         fi
     done < <(git worktree list --porcelain)
 
@@ -69,13 +87,13 @@ cmd_cleanup() {
         return 0
     fi
 
-    for name in "${to_remove[@]}"; do
-        local worktree_path="${worktrees_dir}/${name}"
-        local branch
-        branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || true
+    for i in "${!to_remove[@]}"; do
+        name="${to_remove[$i]}"
+        branch="${to_remove_branches[$i]}"
+        worktree_path="${worktrees_dir}/${name}"
 
         echo "Removing worktree '$name'..."
-        if git worktree remove "$worktree_path" 2>/dev/null; then
+        if remove_error=$(git worktree remove "$worktree_path" 2>&1); then
             # Delete the branch if it still exists
             if [[ -n "$branch" ]] && [[ "$branch" != "$default_branch" ]]; then
                 if git rev-parse --verify "$branch" > /dev/null 2>&1; then
@@ -83,8 +101,9 @@ cmd_cleanup() {
                 fi
             fi
             echo "  Removed worktree and branch '$branch'"
+            ((removed_count++))
         else
-            echo "  Skipping '$name': worktree has uncommitted changes (use 'sprout rm -f $name' to force)" >&2
+            echo "  Skipping '$name': $remove_error (use 'sprout rm -f $name' to force)" >&2
         fi
     done
 
@@ -93,5 +112,5 @@ cmd_cleanup() {
         rmdir "$worktrees_dir" 2>/dev/null || true
     fi
 
-    echo "Cleanup complete: removed ${#to_remove[@]} worktree(s)"
+    echo "Cleanup complete: removed ${removed_count} worktree(s)"
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -49,7 +49,8 @@ test_libraries_exist() {
     [ -f "$PROJECT_ROOT/lib/commands/rm.sh" ] && \
     [ -f "$PROJECT_ROOT/lib/commands/open.sh" ] && \
     [ -f "$PROJECT_ROOT/lib/commands/start.sh" ] && \
-    [ -f "$PROJECT_ROOT/lib/commands/checkout.sh" ]
+    [ -f "$PROJECT_ROOT/lib/commands/checkout.sh" ] && \
+    [ -f "$PROJECT_ROOT/lib/commands/cleanup.sh" ]
 }
 
 # Test: Help command works
@@ -547,6 +548,270 @@ test_checkout_fails_nonexistent() {
     [ $exit_code -ne 0 ]
 }
 
+# Test: Cleanup removes merged worktrees
+test_cleanup_removes_merged() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    # Create a test repo with 'main' as default branch
+    local test_repo="$temp_dir/test-repo"
+    git init -b main "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    # Initialize sprout config
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create a worktree on a branch that is already merged (same as main)
+    "$PROJECT_ROOT/bin/sprout" add "merged-wt" -b main > /dev/null 2>&1 || true
+
+    # Verify worktree exists before cleanup
+    local existed_before=false
+    if [[ -d "$temp_dir/worktrees/test-repo/merged-wt" ]]; then
+        existed_before=true
+    fi
+
+    # Run cleanup
+    "$PROJECT_ROOT/bin/sprout" cleanup > /dev/null 2>&1
+    local exit_code=$?
+
+    # Verify worktree was removed
+    local removed=false
+    if [[ ! -d "$temp_dir/worktrees/test-repo/merged-wt" ]]; then
+        removed=true
+    fi
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    [ $exit_code -eq 0 ] && [ "$existed_before" = true ] && [ "$removed" = true ]
+}
+
+# Test: Cleanup keeps unmerged worktrees
+test_cleanup_keeps_unmerged() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    # Create a test repo with 'main' as default branch
+    local test_repo="$temp_dir/test-repo"
+    git init -b main "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    # Initialize sprout config
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create a worktree and add an unmerged commit to it
+    "$PROJECT_ROOT/bin/sprout" add "unmerged-wt" -b main > /dev/null 2>&1 || true
+    local wt_path="$temp_dir/worktrees/test-repo/unmerged-wt"
+    cd "$wt_path"
+    git checkout -b "feature-unmerged" > /dev/null 2>&1
+    echo "new work" > new-file.txt
+    git add new-file.txt > /dev/null 2>&1
+    git commit -m "Unmerged work" > /dev/null 2>&1
+    cd "$test_repo"
+
+    # Run cleanup
+    "$PROJECT_ROOT/bin/sprout" cleanup > /dev/null 2>&1
+    local exit_code=$?
+
+    # Verify worktree still exists
+    local still_exists=false
+    if [[ -d "$wt_path" ]]; then
+        still_exists=true
+    fi
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    [ $exit_code -eq 0 ] && [ "$still_exists" = true ]
+}
+
+# Test: Cleanup with no worktrees
+test_cleanup_no_worktrees() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    local test_repo="$temp_dir/test-repo"
+    git init -b main "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Run cleanup with no worktrees - should succeed
+    "$PROJECT_ROOT/bin/sprout" cleanup > /dev/null 2>&1
+    local exit_code=$?
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo"
+    rm -rf "$temp_dir"
+
+    [ $exit_code -eq 0 ]
+}
+
+# Test: Cleanup --dry-run does not remove anything
+test_cleanup_dry_run() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    local test_repo="$temp_dir/test-repo"
+    git init -b main "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create a merged worktree
+    "$PROJECT_ROOT/bin/sprout" add "dry-run-wt" -b main > /dev/null 2>&1 || true
+
+    # Run cleanup with --dry-run
+    local output
+    output=$("$PROJECT_ROOT/bin/sprout" cleanup --dry-run 2>&1)
+    local exit_code=$?
+
+    # Verify worktree still exists
+    local still_exists=false
+    if [[ -d "$temp_dir/worktrees/test-repo/dry-run-wt" ]]; then
+        still_exists=true
+    fi
+
+    # Verify output mentions what would be removed
+    local mentions_worktree=false
+    if [[ "$output" == *"dry-run-wt"* ]]; then
+        mentions_worktree=true
+    fi
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    [ $exit_code -eq 0 ] && [ "$still_exists" = true ] && [ "$mentions_worktree" = true ]
+}
+
+# Test: Cleanup skips worktrees with uncommitted changes
+test_cleanup_skips_dirty_worktree() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    local test_repo="$temp_dir/test-repo"
+    git init -b main "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create a worktree on main (merged), then dirty it
+    "$PROJECT_ROOT/bin/sprout" add "dirty-wt" -b main > /dev/null 2>&1 || true
+    local wt_path="$temp_dir/worktrees/test-repo/dirty-wt"
+    echo "uncommitted work" > "$wt_path/dirty-file.txt"
+
+    # Run cleanup
+    local output
+    output=$("$PROJECT_ROOT/bin/sprout" cleanup 2>&1)
+    local exit_code=$?
+
+    # Verify worktree still exists (was skipped)
+    local still_exists=false
+    if [[ -d "$wt_path" ]]; then
+        still_exists=true
+    fi
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    [ "$still_exists" = true ]
+}
+
+# Test: Cleanup deletes the local branch after removing worktree
+test_cleanup_deletes_branch() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    local test_repo="$temp_dir/test-repo"
+    git init -b main "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create a branch (at same commit as main, so it's "merged"), then checkout into worktree
+    git branch "feature-done" > /dev/null 2>&1
+    "$PROJECT_ROOT/bin/sprout" checkout "feature-done" > /dev/null 2>&1 || true
+
+    # Verify branch exists before cleanup
+    local branch_existed_before=false
+    if git rev-parse --verify "feature-done" > /dev/null 2>&1; then
+        branch_existed_before=true
+    fi
+
+    # Run cleanup
+    "$PROJECT_ROOT/bin/sprout" cleanup > /dev/null 2>&1
+
+    # Check if branch was deleted
+    local branch_deleted=false
+    if ! git rev-parse --verify "feature-done" > /dev/null 2>&1; then
+        branch_deleted=true
+    fi
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    [ "$branch_existed_before" = true ] && [ "$branch_deleted" = true ]
+}
+
 # Run all tests
 echo "Core Tests:"
 echo "-----------"
@@ -582,6 +847,16 @@ echo "-----------------------"
 run_test "Checkout an existing local branch" "test_checkout_local_branch"
 run_test "Checkout a remote-only branch" "test_checkout_remote_only_branch"
 run_test "Checkout fails for nonexistent branch" "test_checkout_fails_nonexistent"
+
+echo ""
+echo "Cleanup Command Tests:"
+echo "----------------------"
+run_test "Cleanup removes merged worktrees" "test_cleanup_removes_merged"
+run_test "Cleanup keeps unmerged worktrees" "test_cleanup_keeps_unmerged"
+run_test "Cleanup with no worktrees" "test_cleanup_no_worktrees"
+run_test "Cleanup --dry-run does not remove anything" "test_cleanup_dry_run"
+run_test "Cleanup skips worktrees with uncommitted changes" "test_cleanup_skips_dirty_worktree"
+run_test "Cleanup deletes the local branch" "test_cleanup_deletes_branch"
 
 echo ""
 echo "======================="

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -763,7 +763,49 @@ test_cleanup_skips_dirty_worktree() {
     rm -rf "$test_repo" "$temp_dir/worktrees"
     rm -rf "$temp_dir"
 
-    [ "$still_exists" = true ]
+    [ $exit_code -eq 0 ] && [ "$still_exists" = true ]
+}
+
+# Test: Cleanup skips worktrees with detached HEAD
+test_cleanup_skips_detached_head() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    local test_repo="$temp_dir/test-repo"
+    git init -b main "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create a worktree in detached HEAD state
+    local wt_path="$temp_dir/worktrees/test-repo/detached-wt"
+    mkdir -p "$(dirname "$wt_path")"
+    git worktree add --detach "$wt_path" > /dev/null 2>&1
+
+    # Run cleanup
+    "$PROJECT_ROOT/bin/sprout" cleanup > /dev/null 2>&1
+    local exit_code=$?
+
+    # Verify detached worktree was NOT removed
+    local still_exists=false
+    if [[ -d "$wt_path" ]]; then
+        still_exists=true
+    fi
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    [ $exit_code -eq 0 ] && [ "$still_exists" = true ]
 }
 
 # Test: Cleanup deletes the local branch after removing worktree
@@ -856,6 +898,7 @@ run_test "Cleanup keeps unmerged worktrees" "test_cleanup_keeps_unmerged"
 run_test "Cleanup with no worktrees" "test_cleanup_no_worktrees"
 run_test "Cleanup --dry-run does not remove anything" "test_cleanup_dry_run"
 run_test "Cleanup skips worktrees with uncommitted changes" "test_cleanup_skips_dirty_worktree"
+run_test "Cleanup skips worktrees with detached HEAD" "test_cleanup_skips_detached_head"
 run_test "Cleanup deletes the local branch" "test_cleanup_deletes_branch"
 
 echo ""

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -596,6 +596,62 @@ test_cleanup_removes_merged() {
     [ $exit_code -eq 0 ] && [ "$existed_before" = true ] && [ "$removed" = true ]
 }
 
+# Test: Cleanup removes worktree whose branch was actually merged (not just at same commit)
+test_cleanup_removes_actually_merged() {
+    local temp_dir=$(mktemp -d)
+    export HOME="$temp_dir"
+
+    local test_repo="$temp_dir/test-repo"
+    git init -b main "$test_repo" > /dev/null 2>&1
+    cd "$test_repo"
+    git config user.name "Test User" > /dev/null 2>&1
+    git config user.email "test@test.com" > /dev/null 2>&1
+
+    echo "test" > README.md
+    git add README.md > /dev/null 2>&1
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    # Initialize sprout config
+    source "$PROJECT_ROOT/lib/config.sh"
+    init_config > /dev/null 2>&1
+    set_config "worktree_dir" "$temp_dir/worktrees"
+
+    # Create a feature branch with a commit, then merge it into main
+    git checkout -b "feature-merged" > /dev/null 2>&1
+    echo "feature work" > feature.txt
+    git add feature.txt > /dev/null 2>&1
+    git commit -m "Feature work" > /dev/null 2>&1
+    git checkout main > /dev/null 2>&1
+    git merge "feature-merged" --no-ff -m "Merge feature-merged" > /dev/null 2>&1
+
+    # Create a worktree for the now-merged feature branch
+    "$PROJECT_ROOT/bin/sprout" checkout "feature-merged" > /dev/null 2>&1 || true
+    local wt_path="$temp_dir/worktrees/test-repo/feature-merged"
+
+    # Verify worktree exists before cleanup
+    local existed_before=false
+    if [[ -d "$wt_path" ]]; then
+        existed_before=true
+    fi
+
+    # Run cleanup
+    "$PROJECT_ROOT/bin/sprout" cleanup > /dev/null 2>&1
+    local exit_code=$?
+
+    # Verify worktree was removed
+    local removed=false
+    if [[ ! -d "$wt_path" ]]; then
+        removed=true
+    fi
+
+    # Cleanup
+    cd "$temp_dir"
+    rm -rf "$test_repo" "$temp_dir/worktrees"
+    rm -rf "$temp_dir"
+
+    [ $exit_code -eq 0 ] && [ "$existed_before" = true ] && [ "$removed" = true ]
+}
+
 # Test: Cleanup keeps unmerged worktrees
 test_cleanup_keeps_unmerged() {
     local temp_dir=$(mktemp -d)
@@ -763,7 +819,7 @@ test_cleanup_skips_dirty_worktree() {
     rm -rf "$test_repo" "$temp_dir/worktrees"
     rm -rf "$temp_dir"
 
-    [ $exit_code -eq 0 ] && [ "$still_exists" = true ]
+    [ $exit_code -ne 0 ] && [ "$still_exists" = true ]
 }
 
 # Test: Cleanup skips worktrees with detached HEAD
@@ -894,6 +950,7 @@ echo ""
 echo "Cleanup Command Tests:"
 echo "----------------------"
 run_test "Cleanup removes merged worktrees" "test_cleanup_removes_merged"
+run_test "Cleanup removes actually merged worktrees (with commits)" "test_cleanup_removes_actually_merged"
 run_test "Cleanup keeps unmerged worktrees" "test_cleanup_keeps_unmerged"
 run_test "Cleanup with no worktrees" "test_cleanup_no_worktrees"
 run_test "Cleanup --dry-run does not remove anything" "test_cleanup_dry_run"


### PR DESCRIPTION
## Summary
This PR adds a new `cleanup` command to sprout that automatically removes worktrees whose branches have been merged into the default branch. This helps keep the repository clean by removing stale worktrees.

## Key Changes
- **New cleanup command** (`lib/commands/cleanup.sh`): Implements the core functionality to identify and remove worktrees with merged branches
  - Supports `--dry-run` / `-n` flag to preview what would be removed without making changes
  - Safely handles worktrees with uncommitted changes by skipping them
  - Automatically deletes the associated branch after removing the worktree
  - Cleans up empty parent directories after removal

- **Command integration**: Updated main sprout script to register and dispatch the cleanup command

- **Help documentation**: Added cleanup command to the help message with usage information

- **Shell completion support**: Added completion rules for all three supported shells:
  - Bash: Completes the `--dry-run` and `-n` flags
  - Zsh: Provides flag descriptions and completion
  - Fish: Adds command description and flag completion

## Implementation Details
- The command uses `git worktree list --porcelain` to enumerate all worktrees
- Filters to only managed worktrees (those under the configured worktrees directory)
- Uses `git merge-base --is-ancestor` to check if a branch has been merged
- Gracefully handles errors and skips worktrees with uncommitted changes
- Provides clear user feedback about what was removed and any issues encountered

https://claude.ai/code/session_01PtNixX1hD9TgT2VpDZKbBb